### PR TITLE
Check if output RR is nil

### DIFF
--- a/dns/dns_store.go
+++ b/dns/dns_store.go
@@ -85,7 +85,7 @@ func stringsToRRs(sList []string) []dns.RR {
 	rrs := []dns.RR{}
 	for _, s := range sList {
 		rr, err := dns.NewRR(s)
-		if err == nil {
+		if err == nil && rr != nil {
 			rrs = append(rrs, rr)
 		}
 	}
@@ -223,7 +223,7 @@ func (s *dnsStore) getGlueRecords(nsName string) []*dns.RR {
 		if glueARecords, ok := typeMap[dns.TypeA]; ok {
 			for _, glueRecordString := range glueARecords {
 				rr, err := dns.NewRR(glueRecordString)
-				if err == nil {
+				if err == nil && rr != nil {
 					hasPreciseMatch = true
 					glueRecords = append(glueRecords, &rr)
 				}
@@ -247,7 +247,7 @@ func (s *dnsStore) getGlueRecords(nsName string) []*dns.RR {
 			wildcardGlueRecordList := wildcardTypeMap[dns.TypeA]
 			for _, wildCardGlueRecordString := range wildcardGlueRecordList {
 				rr, err := dns.NewRR(wildCardGlueRecordString)
-				if err == nil {
+				if err == nil && rr != nil {
 					hasMatch = true
 					glueRecords = append(glueRecords, &rr)
 				}
@@ -272,7 +272,7 @@ func (s *dnsStore) getCacheRecords(domainName string, qType uint16) []*dns.RR {
 				// check cache validity
 				timeDiff := uint32(time.Since(crInfo.createTime).Seconds())
 				// newTTL := validCache(&crInfo)
-				if err == nil && timeDiff < crInfo.ttl {
+				if err == nil && cr != nil && timeDiff < crInfo.ttl {
 					// restore ttl
 					cr.Header().Ttl = crInfo.ttl - timeDiff
 					cacheRecords = append(cacheRecords, &cr)
@@ -300,7 +300,7 @@ func (s *dnsStore) HandleSingleQuestion(name string, qType uint16, r *dns.Msg) b
 		if rrStringList != nil && len(rrStringList) != 0 {
 			for _, rrString := range rrStringList {
 				rr, err := dns.NewRR(rrString)
-				if err == nil {
+				if err == nil && rr != nil {
 					hasPreciseMatch = true // We have a precise match if we push entry
 					r.Answer = append(r.Answer, rr)
 				}
@@ -365,7 +365,7 @@ func (s *dnsStore) HandleSingleQuestion(name string, qType uint16, r *dns.Msg) b
 			wildcardRRList := wildcardTypeMap[qType]
 			for _, wildCardRRString := range wildcardRRList {
 				rr, err := dns.NewRR(wildCardRRString)
-				if err == nil {
+				if err == nil && rr != nil {
 					hasMatch = true
 					// Spec asks us to change the owner to be w/o star
 					rr.Header().Name = domainName
@@ -486,7 +486,7 @@ func (s *dnsStore) readCommits(commitC <-chan *string, errorC <-chan error) {
 		switch proposal.ProposalType {
 		case AddRR:
 			rr, err := dns.NewRR(proposal.RRString)
-			if err == nil {
+			if err == nil && rr != nil {
 				s.mu.Lock()
 				s.insertRR(rr)
 				s.mu.Unlock()

--- a/dns/hash_server/hash_server.go
+++ b/dns/hash_server/hash_server.go
@@ -84,7 +84,7 @@ func (c *jsonClusterInfo) intoClusterInfo() clusterInfo {
 	now := time.Now()
 	for _, m := range c.Members {
 		glueRecord, err := dns.NewRR(m.GlueRecord)
-		if err != nil {
+		if err != nil || glueRecord == nil {
 			continue
 		}
 		mi := nsInfo{
@@ -151,7 +151,7 @@ func serveHashServerHTTPAPI(store *hashServerStore, port int, done chan<- error)
 		rrString := string(body)
 
 		rr, err := dns.NewRR(rrString)
-		if err != nil {
+		if err != nil || rr == nil {
 			log.Println("Bad RR request")
 			http.Error(w, "Bad RR request", http.StatusBadRequest)
 			return

--- a/dns/httpapi.go
+++ b/dns/httpapi.go
@@ -14,8 +14,8 @@ import (
 )
 
 func checkValidRRString(s string) bool {
-	_, err := dns.NewRR(s)
-	return err == nil
+	rr, err := dns.NewRR(s)
+	return err == nil && rr != nil
 }
 
 // func (h *dnsHTTPAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -158,7 +158,7 @@ func serveHTTPAPI(store *dnsStore, port int, confChangeC chan<- raftpb.ConfChang
 		rrString := string(body)
 
 		rr, err := dns.NewRR(rrString)
-		if err != nil {
+		if err != nil || rr == nil {
 			log.Println("Bad cache RR request")
 			http.Error(w, "Bad RR request", http.StatusBadRequest)
 			return


### PR DESCRIPTION
Closes #7 

It seems that sometimes `dns.NewRR(...)` can strangely silently fail with output `rr` as `nil` while `err` still being `nil`. Add this check to all `NewRR` invocations to avoid segfault.