### PR TITLE
Add basic resharding record migration logic for new cluster (no GC yet)

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -263,12 +263,6 @@ func getClusterInfo(hashServer string) []jsonClusterInfo {
 	return jsonClusters
 }
 
-func disableWrites(hashServer string) {
-	// send write disable request to hash server and
-	// wait for ack before return
-	log.Println("Hash Server write disabled")
-}
-
 func updateConfig(clusters []jsonClusterInfo, configPath *string) []jsonClusterInfo {
 	file, err := os.Open(*configPath)
 	if err != nil {
@@ -405,10 +399,21 @@ func retrieveRR(clusters []jsonClusterInfo, store *dnsStore) {
 	}
 }
 
+// TODO: notify every other cluster to garbage collect
+// the records that they no longer need to keep b/c of
+// the new cluster
 func startGarbageCollect(clusters []jsonClusterInfo) {
 	log.Println("Garbage Collection started")
 }
 
+// TODO: notify the hash sverver to stop processing writes
+func disableWrites(hashServer string) {
+	// send write disable request to hash server and
+	// wait for ack before return
+	log.Println("Hash Server write disabled")
+}
+
+// TODO: notify the hash server to start processing writes
 func enableWrites(hashServer string) {
 	log.Println("Enable writes at the hash server at", hashServer)
 }

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -306,7 +306,7 @@ func sendClusterInfo(clusters []jsonClusterInfo, destIP string) {
 	// pick the first member ot send the cluster config to
 	addr := "http://" + destIP + ":9121/addcluster"
 	clusterJSON, err := json.Marshal(clusters)
-	log.Println("Sending cluster info to", addr)
+	log.Println("Sending cluster info", string(clusterJSON), "to", addr)
 	if err != nil {
 		log.Fatal("sendClusterInfo: ", err)
 	}
@@ -341,6 +341,7 @@ func retrieveRR(clusters []jsonClusterInfo, store *dnsStore) {
 			counter := 0
 			for {
 				req, err := http.NewRequest("GET", addr, strings.NewReader(strconv.Itoa(counter)))
+				log.Println(strconv.Itoa(counter))
 				if err != nil {
 					errorC <- err
 					return
@@ -378,6 +379,7 @@ func retrieveRR(clusters []jsonClusterInfo, store *dnsStore) {
 						return
 					}
 					// this is async, might cause too much traffic
+					// no need to acquire locks here since it is proposed through channel
 					store.ProposeAddRR(rrString)
 					log.Println("Adding RR:", rrString)
 				}

--- a/dns/dns_store.go
+++ b/dns/dns_store.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buraksezer/consistent"
 	"github.com/coreos/etcd/snap"
 
 	"github.com/miekg/dns"
@@ -48,6 +49,10 @@ type dnsStore struct {
 	// for sending http Cache requests
 	cluster []string
 	id      int
+	// for adding new cluster and migration
+	config []jsonClusterInfo
+	// to compute if a key should be migrated
+	lookup *consistent.Consistent
 }
 
 func newDNSStore(snapshotter *snap.Snapshotter, proposeC chan<- string, commitC <-chan *string, errorC <-chan error, cluster []string, id int) *dnsStore {

--- a/dns/hash_server/hash_server.go
+++ b/dns/hash_server/hash_server.go
@@ -52,6 +52,7 @@ type clusterInfo struct {
 type hashServerStore struct {
 	clusters map[clusterToken]clusterInfo
 	lookup   *consistent.Consistent
+	mu       sync.RWMutex
 }
 
 /**
@@ -261,7 +262,9 @@ func serveHashServerHTTPAPI(store *hashServerStore, port int, done chan<- error)
 		}
 
 		// update cluster info in dnsStore
+		store.mu.Lock()
 		store.clusters = intoClusterMap(jsonClusters)
+		store.mu.Unlock()
 		// update consistent
 		cfg := consistent.Config{
 			PartitionCount:    len(store.clusters),
@@ -277,6 +280,16 @@ func serveHashServerHTTPAPI(store *hashServerStore, port int, done chan<- error)
 		}
 
 		w.WriteHeader(http.StatusNoContent)
+	})
+
+	router.HandleFunc("/disablewrite", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("disable write operations at hash servers")
+		// TODO: fill in the logic for disabling writes
+	})
+
+	router.HandleFunc("/enablewrite", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("enable write operations at hash servers")
+		// TODO: fill in the logic for enable writes
 	})
 
 	go func() {

--- a/dns/httpapi.go
+++ b/dns/httpapi.go
@@ -21,7 +21,6 @@ func checkValidRRString(s string) bool {
 	return err == nil && rr != nil
 }
 
-<<<<<<< HEAD
 func shouldMigrate(domain string, store *dnsStore) bool {
 	clusterToken := store.lookup.LocateKey([]byte(domain)).String()
 	log.Println("Computed cluster is", clusterToken)
@@ -93,8 +92,6 @@ func (t clusterToken) String() string {
 // 	}
 // }
 
-=======
->>>>>>> master
 type deleteRequestPayload struct {
 	Name         string `json:"name"`
 	RRTypeString string `json:"rrType"`

--- a/dns/httpapi.go
+++ b/dns/httpapi.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
 
+	"github.com/buraksezer/consistent"
+	"github.com/cespare/xxhash"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/miekg/dns"
 
@@ -16,6 +19,25 @@ import (
 func checkValidRRString(s string) bool {
 	rr, err := dns.NewRR(s)
 	return err == nil && rr != nil
+}
+
+func shouldMigrate(domain string, store *dnsStore) bool {
+	clusterToken := store.lookup.LocateKey([]byte(domain)).String()
+	log.Println("Computed cluster ", clusterToken)
+	return clusterToken == store.config[len(store.config)-1].ClusterToken
+}
+
+type hasher struct{}
+
+func (h hasher) Sum64(data []byte) uint64 {
+	// Use a proper hash function for uniformity.
+	return xxhash.Sum64(data)
+}
+
+type clusterToken string
+
+func (t clusterToken) String() string {
+	return string(t)
 }
 
 // func (h *dnsHTTPAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +104,7 @@ func serveHTTPAPI(store *dnsStore, port int, confChangeC chan<- raftpb.ConfChang
 	// PUT /add
 	// body: string(rrString)
 	router.HandleFunc("/add", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Start add")
 		if r.Method != "PUT" {
 			http.Error(w, "Method has to be PUT", http.StatusBadRequest)
 			return
@@ -104,6 +127,7 @@ func serveHTTPAPI(store *dnsStore, port int, confChangeC chan<- raftpb.ConfChang
 		// Optimistic-- no waiting for ack from raft. Value is not yet
 		// committed so a subsequent GET on the key may return old value
 		w.WriteHeader(http.StatusNoContent)
+		log.Println("Done")
 	})
 
 	// PUT /delete
@@ -151,7 +175,7 @@ func serveHTTPAPI(store *dnsStore, port int, confChangeC chan<- raftpb.ConfChang
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Printf("Cannot read /add body: %v\n", err)
+			log.Printf("Cannot read /addcache body: %v\n", err)
 			http.Error(w, "Bad PUT body", http.StatusBadRequest)
 			return
 		}
@@ -172,6 +196,110 @@ func serveHTTPAPI(store *dnsStore, port int, confChangeC chan<- raftpb.ConfChang
 	})
 
 	// TODO: confChange requests
+	router.HandleFunc("/addcluster", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("add cluster")
+		if r.Method != "PUT" {
+			http.Error(w, "Method has to be PUT", http.StatusBadRequest)
+			return
+		}
+
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("Cannot read /addcluster body: %v\n", err)
+			http.Error(w, "Bad PUT body", http.StatusBadRequest)
+			return
+		}
+
+		jsonClusters := make([]jsonClusterInfo, 0)
+		err = json.Unmarshal(body, &jsonClusters)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// update cluster info in dnsStore
+		store.config = jsonClusters
+		PrintClusterConfig(store.config)
+		// update consistent
+		cfg := consistent.Config{
+			PartitionCount:    len(store.config),
+			ReplicationFactor: 2, // We are forced to have number larger than 1
+			Load:              3,
+			Hasher:            hasher{},
+		}
+		log.Println("Received cluster update, setting lookup")
+		store.lookup = consistent.New(nil, cfg)
+		for _, clusterJSON := range store.config {
+			store.lookup.Add(clusterToken(clusterJSON.ClusterToken))
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// TODO: confChange requests
+	var domainNames []string
+	type recordJSON struct {
+		DomainName string
+		RecordsMap dnsRRTypeMap
+	}
+
+	router.HandleFunc("/getrecord", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("HTTP request /getrecord")
+		if r.Method != "GET" {
+			http.Error(w, "Method has to be GET", http.StatusBadRequest)
+			return
+		}
+
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("Cannot read /addcluster body: %v\n", err)
+			http.Error(w, "Bad PUT body", http.StatusBadRequest)
+			return
+		}
+		index, err := strconv.Atoi(string(body))
+		log.Println("Got index ", index)
+		if err != nil {
+			log.Printf("Cannot parse getrecord argument: %v\n", err)
+			http.Error(w, "Bad index", http.StatusBadRequest)
+			return
+		}
+
+		var records []string
+		if index >= len(store.store) {
+			// send a DONE message
+			log.Println("Done migrating")
+			records = append(records, "Done")
+		} else {
+			if index == 0 {
+				// start migrating resource records
+				// make a copy of keys (domain names)
+				for k := range store.store {
+					domainNames = append(domainNames, k)
+				}
+				log.Println("key copy: ", domainNames)
+			}
+
+			// check if this domain name should be migrated
+			domain := domainNames[index]
+			log.Println("Calling shouldMigrate with", domain, store.lookup)
+			log.Println(store.lookup.LocateKey([]byte(domain)).String())
+			if shouldMigrate(domain, store) {
+				for _, rrs := range store.store[domainNames[index]] {
+					records = append(records, rrs...)
+				}
+			}
+		}
+
+		b, err := json.Marshal(records)
+		if err != nil {
+			log.Printf("Marshal failed: %v\n", err)
+			http.Error(w, "Marshal Failed", http.StatusInternalServerError)
+			return
+		}
+		log.Println(string(b))
+
+		log.Println("Writing RR", string(b))
+		// writes back the json record
+		io.WriteString(w, string(b))
+	})
 
 	go func() {
 		if err := http.ListenAndServe(":"+strconv.Itoa(port), router); err != nil {

--- a/dns/httpapi.go
+++ b/dns/httpapi.go
@@ -23,7 +23,7 @@ func checkValidRRString(s string) bool {
 
 func shouldMigrate(domain string, store *dnsStore) bool {
 	clusterToken := store.lookup.LocateKey([]byte(domain)).String()
-	log.Println("Computed cluster ", clusterToken)
+	log.Println("Computed cluster is", clusterToken)
 	return clusterToken == store.config[len(store.config)-1].ClusterToken
 }
 
@@ -275,11 +275,11 @@ func serveHTTPAPI(store *dnsStore, port int, confChangeC chan<- raftpb.ConfChang
 				for k := range store.store {
 					domainNames = append(domainNames, k)
 				}
-				log.Println("key copy: ", domainNames)
 			}
 
 			// check if this domain name should be migrated
 			domain := domainNames[index]
+			log.Println("Domain is ", domain)
 			// log.Println(store.lookup.LocateKey([]byte(domain)).String())
 			if shouldMigrate(domain, store) {
 				for _, rrs := range store.store[domainNames[index]] {

--- a/dns/main.go
+++ b/dns/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -27,8 +28,11 @@ func main() {
 	cluster := flag.String("cluster", "http://127.0.0.1:9021", "comma separated cluster peers")
 	id := flag.Int("id", 1, "node ID")
 	// PLEASE use 9121! hash_server.go assumes this port for forwarding
-	httpAPIPort := flag.Int("port", 9121, "dns HTTP API server port")
+	httpAPIPort := flag.Int("port", 9122, "dns HTTP API server port")
 	join := flag.Bool("join", false, "join an existing cluster")
+	migrate := flag.Bool("migrate", false, "need to coordinate migration")
+	// include the port in hash server ip addr
+	hashServer := flag.String("hash", "", "the ip address of a hash server to help with migration")
 	// zoneFile := flag.String("zonefile", "", "Zone file provided during init")
 	flag.Parse()
 
@@ -54,5 +58,12 @@ func main() {
 	// For dig queries
 	serveUDPAPI(dnsStore)
 	// For write requests
-	serveHTTPAPI(dnsStore, *httpAPIPort, confChangeC, errorC)
+	fmt.Println("Done")
+	go serveHTTPAPI(dnsStore, *httpAPIPort, confChangeC, errorC)
+
+	fmt.Println(*hashServer)
+	// For migration
+	if *migrate {
+		migrateDNS(dnsStore, hashServer)
+	}
 }

--- a/dns/main.go
+++ b/dns/main.go
@@ -28,11 +28,12 @@ func main() {
 	cluster := flag.String("cluster", "http://127.0.0.1:9021", "comma separated cluster peers")
 	id := flag.Int("id", 1, "node ID")
 	// PLEASE use 9121! hash_server.go assumes this port for forwarding
-	httpAPIPort := flag.Int("port", 9122, "dns HTTP API server port")
+	httpAPIPort := flag.Int("port", 9121, "dns HTTP API server port")
 	join := flag.Bool("join", false, "join an existing cluster")
 	migrate := flag.Bool("migrate", false, "need to coordinate migration")
 	// include the port in hash server ip addr
 	hashServer := flag.String("hash", "", "the ip address of a hash server to help with migration")
+	config := flag.String("config", "", "the path to the json file containing the config for this cluster")
 	// zoneFile := flag.String("zonefile", "", "Zone file provided during init")
 	flag.Parse()
 
@@ -57,13 +58,12 @@ func main() {
 
 	// For dig queries
 	serveUDPAPI(dnsStore)
-	// For write requests
-	fmt.Println("Done")
-	go serveHTTPAPI(dnsStore, *httpAPIPort, confChangeC, errorC)
-
-	fmt.Println(*hashServer)
 	// For migration
 	if *migrate {
-		migrateDNS(dnsStore, hashServer)
+		go migrateDNS(dnsStore, hashServer, config)
 	}
+	// For write requests
+	serveHTTPAPI(dnsStore, *httpAPIPort, confChangeC, errorC)
+
+	fmt.Println(*hashServer)
 }

--- a/dns/main.go
+++ b/dns/main.go
@@ -32,6 +32,8 @@ func main() {
 	migrate := flag.Bool("migrate", false, "need to coordinate migration")
 	// include the port in hash server ip addr
 	hashServer := flag.String("hash", "", "the ip address of a hash server to help with migration")
+	// This config file should contain the JSON representaion of type jsonClusterInfo for the new cluster
+	// see new_config.json for example
 	config := flag.String("config", "", "the path to the json file containing the config for this cluster")
 	usePaged := flag.Bool("page", false, "use paged version of DNS store")
 	// zoneFile := flag.String("zonefile", "", "Zone file provided during init")

--- a/dns/main.go
+++ b/dns/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -64,6 +63,4 @@ func main() {
 	}
 	// For write requests
 	serveHTTPAPI(dnsStore, *httpAPIPort, confChangeC, errorC)
-
-	fmt.Println(*hashServer)
 }

--- a/dns/new_config.json
+++ b/dns/new_config.json
@@ -1,0 +1,9 @@
+{
+	"cluster": "cluster3",
+	"members": [
+		{
+		"name": "ns3.example.com.",
+		"glue": "ns3.example.com. 3600 IN A 172.31.19.166"
+		}
+	]
+}


### PR DESCRIPTION
Basic function for migrating RRs from old clusters to the new cluster and updates config at hash servers. 

Example command for a new cluster to start migration:
`sudo ./dns_server -migrate -hash "172.31.30.97" -config ./new_config.json -port 9121 -cluster "http://172.31.19.166:12379"`


Some functions are not implemented and I will discuss these functions with who picks these tasks:
* Enable/Disable write requests at hash server side.
* Garbage collection of migrated RRs at the old Raft clusters.
